### PR TITLE
Asynchronous operation DB operation fix

### DIFF
--- a/RR.App/Program.cs
+++ b/RR.App/Program.cs
@@ -61,8 +61,8 @@ namespace RR.App
             });
 
             var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__Default");
-            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(connectionString));
-            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(configuration["ConnectionStrings:Default"]));
+            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(connectionString), ServiceLifetime.Transient);
+            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(configuration["ConnectionStrings:Default"]), ServiceLifetime.Transient);
             builder.Services.RegisterRepository();
             builder.Services.RegisterServicesHRIS();
             builder.Services.RegisterServicesATS();


### PR DESCRIPTION
Fixed the following error when calling the save employees endpoint: "A second operation was started on this context instance before a previous operation completed. This is usually caused by different threads concurrently using the same instance of DbContext".