### PR TITLE
Asynchronous operation db fix

### DIFF
--- a/RR.App/Program.cs
+++ b/RR.App/Program.cs
@@ -61,8 +61,8 @@ namespace RR.App
             });
 
             var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__Default");
-            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(connectionString));
-            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(configuration["ConnectionStrings:Default"]));
+            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(connectionString), ServiceLifetime.Transient);
+            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(configuration["ConnectionStrings:Default"]), ServiceLifetime.Transient);
             builder.Services.RegisterRepository();
             builder.Services.RegisterServicesHRIS();
             builder.Services.RegisterServicesATS();

--- a/RR.App/Program.cs
+++ b/RR.App/Program.cs
@@ -61,15 +61,13 @@ namespace RR.App
             });
 
             var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__Default");
-            //builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(connectionString), ServiceLifetime.Transient);
-            //builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(configuration["ConnectionStrings:Default"]), ServiceLifetime.Transient);
-            //builder.Services.AddTransient<DatabaseContext>(options => options.UseNpgsql(connectionString));
-            //builder.Services.AddTransient<DatabaseContext>(options => options.UseNpgsql(configuration["ConnectionStrings:Default"]));
+            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(connectionString), ServiceLifetime.Transient);
             builder.Services.AddTransient<DatabaseContext>(serviceProvider =>
             {
-                var connectionString = serviceProvider.GetRequiredService<IConfiguration>()["ConnectionStrings:Default"];
+
+                var defaultConnectionString = serviceProvider.GetRequiredService<IConfiguration>()["ConnectionStrings:Default"];
                 var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
-                optionsBuilder.UseNpgsql(connectionString);
+                optionsBuilder.UseNpgsql(defaultConnectionString);
                 return new DatabaseContext(optionsBuilder.Options);
             });
             builder.Services.RegisterRepository();

--- a/RR.App/Program.cs
+++ b/RR.App/Program.cs
@@ -61,8 +61,17 @@ namespace RR.App
             });
 
             var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__Default");
-            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(connectionString), ServiceLifetime.Transient);
-            builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(configuration["ConnectionStrings:Default"]), ServiceLifetime.Transient);
+            //builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(connectionString), ServiceLifetime.Transient);
+            //builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(configuration["ConnectionStrings:Default"]), ServiceLifetime.Transient);
+            //builder.Services.AddTransient<DatabaseContext>(options => options.UseNpgsql(connectionString));
+            //builder.Services.AddTransient<DatabaseContext>(options => options.UseNpgsql(configuration["ConnectionStrings:Default"]));
+            builder.Services.AddTransient<DatabaseContext>(serviceProvider =>
+            {
+                var connectionString = serviceProvider.GetRequiredService<IConfiguration>()["ConnectionStrings:Default"];
+                var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
+                optionsBuilder.UseNpgsql(connectionString);
+                return new DatabaseContext(optionsBuilder.Options);
+            });
             builder.Services.RegisterRepository();
             builder.Services.RegisterServicesHRIS();
             builder.Services.RegisterServicesATS();

--- a/RR.App/Program.cs
+++ b/RR.App/Program.cs
@@ -64,7 +64,6 @@ namespace RR.App
             builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(connectionString), ServiceLifetime.Transient);
             builder.Services.AddTransient<DatabaseContext>(serviceProvider =>
             {
-
                 var defaultConnectionString = serviceProvider.GetRequiredService<IConfiguration>()["ConnectionStrings:Default"];
                 var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
                 optionsBuilder.UseNpgsql(defaultConnectionString);

--- a/RR.App/Program.cs
+++ b/RR.App/Program.cs
@@ -62,13 +62,6 @@ namespace RR.App
 
             var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__Default");
             builder.Services.AddDbContext<DatabaseContext>(options => options.UseNpgsql(connectionString), ServiceLifetime.Transient);
-            builder.Services.AddTransient<DatabaseContext>(serviceProvider =>
-            {
-                var defaultConnectionString = serviceProvider.GetRequiredService<IConfiguration>()["ConnectionStrings:Default"];
-                var optionsBuilder = new DbContextOptionsBuilder<DatabaseContext>();
-                optionsBuilder.UseNpgsql(defaultConnectionString);
-                return new DatabaseContext(optionsBuilder.Options);
-            });
             builder.Services.RegisterRepository();
             builder.Services.RegisterServicesHRIS();
             builder.Services.RegisterServicesATS();


### PR DESCRIPTION
Fixed multithreading issues with postgres DB when trying to add a new user. No longer getting the following error when calling the save employee endpoint: "A second operation was started on this context instance before a previous operation completed. This is usually caused by different threads concurrently using the same instance of DbContext."