### PR TITLE
Employee Qualification Controller Unit Test

### DIFF
--- a/RR.App.Tests/Controllers/HRIS/EmployeeQualificationControllerUnitTests.cs
+++ b/RR.App.Tests/Controllers/HRIS/EmployeeQualificationControllerUnitTests.cs
@@ -3,7 +3,9 @@ using HRIS.Models.Enums.QualificationEnums;
 using HRIS.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using RGO.Tests.Data.Models;
 using RR.App.Controllers.HRIS;
+using RR.Tests.Data.Models.HRIS;
 using RR.UnitOfWork.Entities.HRIS;
 using Xunit;
 
@@ -105,30 +107,19 @@ public class EmployeeQualificationControllerUnitTests
     [Fact]
     public async Task GetEmployeeQualificationByEmployeeIdReturnsOkObjectResultWithQualifications()
     {
-        var employeeId = 1;
-        var qualifications = new List<EmployeeQualificationDto>
+        var listOfEmployeeQualificationDto = new List<EmployeeQualificationDto>()
             {
-                new EmployeeQualificationDto
-                {
-                    Id = 1,
-                    EmployeeId = employeeId,
-                    HighestQualification = HighestQualification.Bachelor,
-                    School = "University of Africa",
-                    Degree = "Bachelor of Science",
-                    FieldOfStudy = "Computer Science",
-                    NQFLevel = NQFLevel.Level7,
-                    Year = new DateOnly(2020, 1, 1)
-                }
+                EmployeeQualificationTestData.EmployeeQualification
             };
 
-        _mockEmployeeQualificationService.Setup(x => x.GetAllEmployeeQualificationsByEmployeeId(employeeId))
-            .ReturnsAsync(qualifications);
+        _mockEmployeeQualificationService.Setup(x => x.GetAllEmployeeQualificationsByEmployeeId(EmployeeQualificationTestData.EmployeeQualification.Id))
+            .ReturnsAsync(listOfEmployeeQualificationDto);
 
-        var result = await _employeeQualificationController.GetEmployeeQualificationByEmployeeId(employeeId);
+        var result = await _employeeQualificationController.GetEmployeeQualificationByEmployeeId(EmployeeQualificationTestData.EmployeeQualification.Id);
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnValue = Assert.IsType<List<EmployeeQualificationDto>>(okResult.Value);
-        Assert.Equal(qualifications, returnValue);
+        Assert.Equal(listOfEmployeeQualificationDto, returnValue);
     }
 
     [Fact]
@@ -164,27 +155,16 @@ public class EmployeeQualificationControllerUnitTests
     [Fact]
     public async Task DeleteEmployeeQualificationReturnsOkObjectResultWithDeletedQualification()
     {
-        var qualificationId = 1;
-        var deletedQualification = new EmployeeQualificationDto
-        {
-            Id = qualificationId,
-            EmployeeId = 1,
-            HighestQualification = HighestQualification.Bachelor,
-            School = "University of Africa",
-            Degree = "Bachelor of Science",
-            FieldOfStudy = "Computer Science",
-            NQFLevel = NQFLevel.Level7,
-            Year = new DateOnly(2020, 1, 1)
-        };
+        var EmployeeQualificationDto = EmployeeQualificationTestData.EmployeeQualification; 
 
-        _mockEmployeeQualificationService.Setup(x => x.DeleteEmployeeQualification(qualificationId))
-            .ReturnsAsync(deletedQualification);
+        _mockEmployeeQualificationService.Setup(x => x.DeleteEmployeeQualification(EmployeeQualificationDto.Id))
+            .ReturnsAsync(EmployeeQualificationDto);
 
-        var result = await _employeeQualificationController.DeleteEmployeeQualification(qualificationId);
+        var result = await _employeeQualificationController.DeleteEmployeeQualification(EmployeeQualificationDto.Id);
 
         var okResult = Assert.IsType<OkObjectResult>(result);
         var returnValue = Assert.IsType<EmployeeQualificationDto>(okResult.Value);
-        Assert.Equal(deletedQualification, returnValue);
+        Assert.Equal(EmployeeQualificationDto, returnValue);
     }
 
     [Fact]
@@ -221,27 +201,19 @@ public class EmployeeQualificationControllerUnitTests
     [Fact]
     public async Task GetAllEmployeeQualifications()
     {
-        var mockEmployeeQualifications = new List<EmployeeQualificationDto>
-        {
-            new EmployeeQualificationDto {
-            Id = 1,
-            EmployeeId = 1,
-            HighestQualification = HighestQualification.Bachelor,
-            School = "University of Africa",
-            Degree = "Bachelor of Science",
-            FieldOfStudy = "Computer Science",
-            NQFLevel = NQFLevel.Level7,
-            Year = new DateOnly(2020, 1, 1)},
-        };
+        var listOfEmployeeQualificationDto = new List<EmployeeQualificationDto>()
+            {
+                EmployeeQualificationTestData.EmployeeQualification
+            };
 
         _mockEmployeeQualificationService.Setup(x => x.GetAllEmployeeQualifications())
-            .ReturnsAsync(mockEmployeeQualifications);
+            .ReturnsAsync(listOfEmployeeQualificationDto);
 
         var result = await _employeeQualificationController.GetAllEmployeeQualifications();
 
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var returnValue = Assert.IsType<List<EmployeeQualificationDto>>(okResult.Value);
-        Assert.Equal(mockEmployeeQualifications, returnValue);
+        Assert.Equal(listOfEmployeeQualificationDto, returnValue);
     }
 
     [Fact]

--- a/RR.App.Tests/Controllers/HRIS/EmployeeQualificationControllerUnitTests.cs
+++ b/RR.App.Tests/Controllers/HRIS/EmployeeQualificationControllerUnitTests.cs
@@ -4,6 +4,7 @@ using HRIS.Services.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using RR.App.Controllers.HRIS;
+using RR.UnitOfWork.Entities.HRIS;
 using Xunit;
 
 namespace RR.App.Tests.Controllers.HRIS;
@@ -215,5 +216,45 @@ public class EmployeeQualificationControllerUnitTests
         var statusCodeResult = Assert.IsType<ObjectResult>(result);
         Assert.Equal(500, statusCodeResult.StatusCode);
         Assert.Equal($"An error occurred while deleting the qualification: {expectedExceptionMessage}", statusCodeResult.Value);
+    }
+
+    [Fact]
+    public async Task GetAllEmployeeQualifications()
+    {
+        var mockEmployeeQualifications = new List<EmployeeQualificationDto>
+        {
+            new EmployeeQualificationDto {
+            Id = 1,
+            EmployeeId = 1,
+            HighestQualification = HighestQualification.Bachelor,
+            School = "University of Africa",
+            Degree = "Bachelor of Science",
+            FieldOfStudy = "Computer Science",
+            NQFLevel = NQFLevel.Level7,
+            Year = new DateOnly(2020, 1, 1)},
+        };
+
+        _mockEmployeeQualificationService.Setup(x => x.GetAllEmployeeQualifications())
+            .ReturnsAsync(mockEmployeeQualifications);
+
+        var result = await _employeeQualificationController.GetAllEmployeeQualifications();
+
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        var returnValue = Assert.IsType<List<EmployeeQualificationDto>>(okResult.Value);
+        Assert.Equal(mockEmployeeQualifications, returnValue);
+    }
+
+    [Fact]
+    public async Task GetAllEmployeeQualificationsReturnsBadRequestOnException()
+    {
+        var exceptionMessage = "An error occurred while retrieving qualifications";
+
+        _mockEmployeeQualificationService.Setup(x => x.GetAllEmployeeQualifications())
+            .ThrowsAsync(new Exception(exceptionMessage));
+
+        var result = await _employeeQualificationController.GetAllEmployeeQualifications();
+
+        var badRequestResult = Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.StartsWith("An error occurred while retrieving qualifications", (string)badRequestResult.Value);
     }
 }

--- a/RR.App/Controllers/HRIS/EmployeeQualificationController.cs
+++ b/RR.App/Controllers/HRIS/EmployeeQualificationController.cs
@@ -93,10 +93,6 @@ public class EmployeeQualificationController : ControllerBase
         try
         {
             var deletedQualification = await _employeeQualificationService.DeleteEmployeeQualification(id);
-            if (deletedQualification == null)
-            {
-                return NotFound($"No qualification found with ID {id}.");
-            }
             return Ok(deletedQualification);
         }
         catch (KeyNotFoundException knf)

--- a/RR.Tests.Data/Models/HRIS/EmployeeQualificationTestData.cs
+++ b/RR.Tests.Data/Models/HRIS/EmployeeQualificationTestData.cs
@@ -1,0 +1,25 @@
+﻿using HRIS.Models.Enums.QualificationEnums;
+using HRIS.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RR.Tests.Data.Models.HRIS
+{
+    public class EmployeeQualificationTestData
+    {
+        public static EmployeeQualificationDto EmployeeQualification = new EmployeeQualificationDto
+        {
+            Id = 1,
+            EmployeeId = 1,
+            HighestQualification = HighestQualification.Bachelor,
+            School = "University of Africa",
+            Degree = "Bachelor of Science",
+            FieldOfStudy = "Computer Science",
+            NQFLevel = NQFLevel.Level7,
+            Year = new DateOnly(2020, 1, 1)
+        };
+    }
+}


### PR DESCRIPTION
![Screenshot 2024-05-17 091650](https://github.com/RetroRabbit/RGO-Server/assets/123623763/989569fc-fab5-447f-92b7-e9b5056f8e83)

Side Note: The reason for removing the if statement in the DeleteEmployeeQualification function is because there is already a catch that throws an error if qualification is not found.