### PR TITLE
Administrative docs type for admin document uploads

### DIFF
--- a/HRIS.Models/EmployeeDocumentDto.cs
+++ b/HRIS.Models/EmployeeDocumentDto.cs
@@ -10,6 +10,7 @@ public class EmployeeDocumentDto
     public string? FileName { get; set; }
     public FileCategory FileCategory { get; set; }
     public EmployeeFileCategory EmployeeFileCategory { get; set; }
+    public AdminFileCategory AdminFileCategory { get; set; }
     public string? Blob { get; set; }
     public DocumentStatus? Status { get; set; }
     public DateTime UploadDate { get; set; }

--- a/HRIS.Models/Enums/AdminFileCategory.cs
+++ b/HRIS.Models/Enums/AdminFileCategory.cs
@@ -1,0 +1,10 @@
+﻿namespace HRIS.Models.Enums;
+
+public enum AdminFileCategory
+{
+    CriminalCheck,
+    MIE,
+    QualificationCheck,
+    ApprovalOfOffer,
+    ReferenceList
+}

--- a/HRIS.Models/Enums/DocumentType.cs
+++ b/HRIS.Models/Enums/DocumentType.cs
@@ -10,5 +10,6 @@ public enum DocumentType
 {
     StarterKit,
     Additional,
+    Administrative,
     EmployeeDocuments
 }

--- a/HRIS.Models/Enums/EmployeeFileCategory.cs
+++ b/HRIS.Models/Enums/EmployeeFileCategory.cs
@@ -2,14 +2,8 @@
 
 public enum EmployeeFileCategory
 {
-  CriminalCheck,
-  IdentificationDocument,
   Equipment,
-  MockPayslip,
-  MIE,
-  QualificationCheck,
-  RetroCV,
-  ApprovalOfOffer,
-  ConfirmationOfOffer,
-  CostToCompany
+  EmployeePayslip,
+  IdentificationDocument,
+  HighestQualification
 }

--- a/HRIS.Models/SimpleEmployeeDocumentDto.cs
+++ b/HRIS.Models/SimpleEmployeeDocumentDto.cs
@@ -9,6 +9,7 @@ public class SimpleEmployeeDocumentDto
     public string FileName { get; set; }
     public FileCategory FileCategory { get; set; }
     public int EmployeeFileCategory { get; set; }
+    public int AdminFileCategory { get; set; }
     public string Blob { get; set; }
     public DateTime UploadDate { get; set; }
     public string? Reference { get; set; }

--- a/HRIS.Services/Services/EmployeeDocumentService.cs
+++ b/HRIS.Services/Services/EmployeeDocumentService.cs
@@ -35,6 +35,7 @@ public class EmployeeDocumentService : IEmployeeDocumentService
         var status = isAdmin && !sameEmail ? DocumentStatus.ActionRequired : DocumentStatus.PendingApproval;
         var docType = DocumentType.StarterKit;
         var empFileCategory = employeeDocDto.EmployeeFileCategory;
+        var adminFileCategory = employeeDocDto.AdminFileCategory;
 
         switch (documentType)
         {
@@ -52,7 +53,7 @@ public class EmployeeDocumentService : IEmployeeDocumentService
                 break;
         }
 
-        if (docType == DocumentType.EmployeeDocuments)
+        if (docType != DocumentType.StarterKit)
             employeeDocDto.FileCategory = 0;
 
         var employeeDocument = new EmployeeDocumentDto
@@ -63,6 +64,7 @@ public class EmployeeDocumentService : IEmployeeDocumentService
             FileName = employeeDocDto.FileName,
             FileCategory = employeeDocDto.FileCategory,
             EmployeeFileCategory = (EmployeeFileCategory)employeeDocDto.EmployeeFileCategory,
+            AdminFileCategory = (AdminFileCategory)employeeDocDto.AdminFileCategory,
             Blob = employeeDocDto.Blob,
             Status = status,
             UploadDate = DateTime.Now,

--- a/RR.UnitOfWork/Entities/HRIS/EmployeeDocument.cs
+++ b/RR.UnitOfWork/Entities/HRIS/EmployeeDocument.cs
@@ -21,6 +21,7 @@ public class EmployeeDocument : IModel<EmployeeDocumentDto>
         FileName = employeeDocumentsDto.FileName;
         FileCategory = employeeDocumentsDto.FileCategory;
         EmployeeFileCategory = employeeDocumentsDto.EmployeeFileCategory;
+        AdminFileCategory = employeeDocumentsDto.AdminFileCategory;
         Blob = employeeDocumentsDto.Blob;
         Status = employeeDocumentsDto.Status;
         UploadDate = employeeDocumentsDto.UploadDate;
@@ -41,6 +42,8 @@ public class EmployeeDocument : IModel<EmployeeDocumentDto>
     [Column("fileCategory")] public FileCategory FileCategory { get; set; }
 
     [Column("employeeFileCategory")] public EmployeeFileCategory EmployeeFileCategory { get; set; }
+
+    [Column("adminFileCategory")] public AdminFileCategory AdminFileCategory { get; set; }
 
     [Column("blob")] public string? Blob { get; set; }
 
@@ -69,6 +72,7 @@ public class EmployeeDocument : IModel<EmployeeDocumentDto>
                                        FileName = FileName,
                                        FileCategory = FileCategory,
                                        EmployeeFileCategory = EmployeeFileCategory,
+                                       AdminFileCategory = AdminFileCategory,
                                        Blob = Blob,
                                        Status = Status,
                                        UploadDate = UploadDate,

--- a/RR.UnitOfWork/Migrations/20240520082137_AddAdminFileCategory.Designer.cs
+++ b/RR.UnitOfWork/Migrations/20240520082137_AddAdminFileCategory.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RR.UnitOfWork;
@@ -12,9 +13,11 @@ using RR.UnitOfWork;
 namespace RR.UnitOfWork.Migrations
 {
     [DbContext(typeof(DatabaseContext))]
-    partial class DatabaseContextModelSnapshot : ModelSnapshot
+    [Migration("20240520082137_AddAdminFileCategory")]
+    partial class AddAdminFileCategory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/RR.UnitOfWork/Migrations/20240520082137_AddAdminFileCategory.cs
+++ b/RR.UnitOfWork/Migrations/20240520082137_AddAdminFileCategory.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RR.UnitOfWork.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAdminFileCategory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "adminFileCategory",
+                table: "EmployeeDocument",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "adminFileCategory",
+                table: "EmployeeDocument");
+        }
+    }
+}


### PR DESCRIPTION
Unit test coverage of EmployeeDocumentService Unit Tests:

![AdminDocumentsUnitTests](https://github.com/RetroRabbit/RGO-Server/assets/123623759/69c288e2-0a6f-4a53-8953-7ce61beb40f0)

Altered Document type enum on backend:

![AdminDocType](https://github.com/RetroRabbit/RGO-Server/assets/123623759/ca9cca32-1a7a-4e15-862d-3d1ad0595f04)

Swagger Input for uploading an admin document:

![AdminDocSwaggerInput](https://github.com/RetroRabbit/RGO-Server/assets/123623759/489086c3-378b-4aed-8e80-874ff4170a89)

Swagger Response for uploading an admin document:

![AdminDocSwaggerOutput](https://github.com/RetroRabbit/RGO-Server/assets/123623759/898c90fa-3c91-4bf0-8eaf-ffac351befcf)
