### PR TITLE
Admin docs case

### DIFF
--- a/HRIS.Services.Tests/Services/EmployeeDocumentServiceUnitTest.cs
+++ b/HRIS.Services.Tests/Services/EmployeeDocumentServiceUnitTest.cs
@@ -53,6 +53,24 @@ public class EmployeeDocumentServiceUnitTest
         return documents;
     }
 
+    private void SetupMockRoles()
+    {
+        List<Role> roles = new List<Role> { new Role(EmployeeRoleTestData.RoleDtoEmployee) };
+        _employeeServiceMock.Setup(x => x.GetById(employeeId))
+            .ReturnsAsync(EmployeeTestData.EmployeeDto);
+
+        _unitOfWorkMock
+            .Setup(x => x.EmployeeRole.Get(It.IsAny<Expression<Func<EmployeeRole, bool>>>()))
+            .Returns(EmployeeRoleTestData.EmployeeRolesList.AsQueryable().BuildMock());
+
+        _unitOfWorkMock
+            .Setup(x => x.Role.Get(It.IsAny<Expression<Func<Role, bool>>>()))
+            .Returns(roles.AsQueryable().BuildMock());
+
+        _unitOfWorkMock.Setup(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()))
+            .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentPending);
+    }
+
     [Fact]
     public async Task SaveEmployeeDocumentPass()
     {
@@ -81,22 +99,7 @@ public class EmployeeDocumentServiceUnitTest
                     new(EmployeeBankingTestData.EmployeeBankingDto)
                 }.AsQueryable().BuildMock());
 
-
-
-        List<Role> roles = new List<Role> { new Role(EmployeeRoleTestData.RoleDtoEmployee) };
-        _employeeServiceMock.Setup(x => x.GetById(employeeId))
-            .ReturnsAsync(EmployeeTestData.EmployeeDto);
-
-        _unitOfWorkMock
-            .Setup(x => x.EmployeeRole.Get(It.IsAny<Expression<Func<EmployeeRole, bool>>>()))
-            .Returns(EmployeeRoleTestData.EmployeeRolesList.AsQueryable().BuildMock());
-
-        _unitOfWorkMock
-            .Setup(x => x.Role.Get(It.IsAny<Expression<Func<Role, bool>>>()))
-            .Returns(roles.AsQueryable().BuildMock());
-
-        _unitOfWorkMock.Setup(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()))
-            .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentPending);
+        SetupMockRoles();
 
         var result = await _employeeDocumentService.SaveEmployeeDocument(EmployeeDocumentTestData.SimpleDocumentDto, "test@retrorabbit.co.za", 1);
 
@@ -134,22 +137,7 @@ public class EmployeeDocumentServiceUnitTest
                     new(EmployeeBankingTestData.EmployeeBankingDto)
                 }.AsQueryable().BuildMock());
 
-
-
-        List<Role> roles = new List<Role> { new Role(EmployeeRoleTestData.RoleDtoEmployee) };
-        _employeeServiceMock.Setup(x => x.GetById(employeeId))
-            .ReturnsAsync(EmployeeTestData.EmployeeDto);
-
-        _unitOfWorkMock
-            .Setup(x => x.EmployeeRole.Get(It.IsAny<Expression<Func<EmployeeRole, bool>>>()))
-            .Returns(EmployeeRoleTestData.EmployeeRolesList.AsQueryable().BuildMock());
-
-        _unitOfWorkMock
-            .Setup(x => x.Role.Get(It.IsAny<Expression<Func<Role, bool>>>()))
-            .Returns(roles.AsQueryable().BuildMock());
-
-        _unitOfWorkMock.Setup(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()))
-            .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentPending);
+        SetupMockRoles();
 
         var result = await _employeeDocumentService.SaveEmployeeDocument(EmployeeDocumentTestData.SimpleDocumentDto, "test@retrorabbit.co.za", 0);
 
@@ -188,22 +176,7 @@ public class EmployeeDocumentServiceUnitTest
                     new(EmployeeBankingTestData.EmployeeBankingDto)
                 }.AsQueryable().BuildMock());
 
-
-
-        List<Role> roles = new List<Role> { new Role(EmployeeRoleTestData.RoleDtoEmployee) };
-        _employeeServiceMock.Setup(x => x.GetById(employeeId))
-            .ReturnsAsync(EmployeeTestData.EmployeeDto);
-
-        _unitOfWorkMock
-            .Setup(x => x.EmployeeRole.Get(It.IsAny<Expression<Func<EmployeeRole, bool>>>()))
-            .Returns(EmployeeRoleTestData.EmployeeRolesList.AsQueryable().BuildMock());
-
-        _unitOfWorkMock
-            .Setup(x => x.Role.Get(It.IsAny<Expression<Func<Role, bool>>>()))
-            .Returns(roles.AsQueryable().BuildMock());
-
-        _unitOfWorkMock.Setup(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()))
-            .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentPending);
+        SetupMockRoles();
 
         var result = await _employeeDocumentService.SaveEmployeeDocument(EmployeeDocumentTestData.SimpleDocumentDto, "test@retrorabbit.co.za", 3);
 
@@ -215,7 +188,7 @@ public class EmployeeDocumentServiceUnitTest
     }
 
     [Fact]
-    public async Task SaveAdministrativeDocumentPass()
+    public async Task SaveAdministrativeDocumentPass_ShouldReturnSavedDocument()
     {
         _employeeTypeServiceMock
             .Setup(r => r.GetEmployeeType(EmployeeTypeTestData.DeveloperType.Name))
@@ -242,22 +215,7 @@ public class EmployeeDocumentServiceUnitTest
                     new(EmployeeBankingTestData.EmployeeBankingDto)
                 }.AsQueryable().BuildMock());
 
-
-
-        List<Role> roles = new List<Role> { new Role(EmployeeRoleTestData.RoleDtoEmployee) };
-        _employeeServiceMock.Setup(x => x.GetById(employeeId))
-            .ReturnsAsync(EmployeeTestData.EmployeeDto);
-
-        _unitOfWorkMock
-            .Setup(x => x.EmployeeRole.Get(It.IsAny<Expression<Func<EmployeeRole, bool>>>()))
-            .Returns(EmployeeRoleTestData.EmployeeRolesList.AsQueryable().BuildMock());
-
-        _unitOfWorkMock
-            .Setup(x => x.Role.Get(It.IsAny<Expression<Func<Role, bool>>>()))
-            .Returns(roles.AsQueryable().BuildMock());
-
-        _unitOfWorkMock.Setup(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()))
-            .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentPending);
+        SetupMockRoles();
 
         var result = await _employeeDocumentService.SaveEmployeeDocument(EmployeeDocumentTestData.SimpleDocumentDto, "test@retrorabbit.co.za", 2);
 
@@ -296,22 +254,7 @@ public class EmployeeDocumentServiceUnitTest
                     new(EmployeeBankingTestData.EmployeeBankingDto)
                 }.AsQueryable().BuildMock());
 
-
-
-        List<Role> roles = new List<Role> { new Role(EmployeeRoleTestData.RoleDtoEmployee) };
-        _employeeServiceMock.Setup(x => x.GetById(employeeId))
-            .ReturnsAsync(EmployeeTestData.EmployeeDto);
-
-        _unitOfWorkMock
-            .Setup(x => x.EmployeeRole.Get(It.IsAny<Expression<Func<EmployeeRole, bool>>>()))
-            .Returns(EmployeeRoleTestData.EmployeeRolesList.AsQueryable().BuildMock());
-
-        _unitOfWorkMock
-            .Setup(x => x.Role.Get(It.IsAny<Expression<Func<Role, bool>>>()))
-            .Returns(roles.AsQueryable().BuildMock());
-
-        _unitOfWorkMock.Setup(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()))
-            .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentPending);
+        SetupMockRoles();
 
         var result = await _employeeDocumentService.SaveEmployeeDocument(EmployeeDocumentTestData.SimpleDocumentDto, "test@retrorabbit.co.za", 5);
 
@@ -349,22 +292,7 @@ public class EmployeeDocumentServiceUnitTest
                     new(EmployeeBankingTestData.EmployeeBankingDto)
                 }.AsQueryable().BuildMock());
 
-
-
-        List<Role> roles = new List<Role> { new Role(EmployeeRoleTestData.RoleDtoEmployee) };
-        _employeeServiceMock.Setup(x => x.GetById(employeeId))
-            .ReturnsAsync(EmployeeTestData.EmployeeDto);
-
-        _unitOfWorkMock
-            .Setup(x => x.EmployeeRole.Get(It.IsAny<Expression<Func<EmployeeRole, bool>>>()))
-            .Returns(EmployeeRoleTestData.EmployeeRolesList.AsQueryable().BuildMock());
-
-        _unitOfWorkMock
-            .Setup(x => x.Role.Get(It.IsAny<Expression<Func<Role, bool>>>()))
-            .Returns(roles.AsQueryable().BuildMock());
-
-        _unitOfWorkMock.Setup(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()))
-            .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentPending);
+        SetupMockRoles();
 
         var result = await _employeeDocumentService.addNewAdditionalDocument(EmployeeDocumentTestData.SimpleDocumentDto, "test@retrorabbit.co.za", 1);
 
@@ -423,21 +351,10 @@ public class EmployeeDocumentServiceUnitTest
                     new(EmployeeBankingTestData.EmployeeBankingDto)
                 }.AsQueryable().BuildMock());
 
-        List<Role> roles = new List<Role> { new Role(EmployeeRoleTestData.RoleDtoAdmin) };
-
-        _unitOfWorkMock
-            .Setup(x => x.EmployeeRole.Get(It.IsAny<Expression<Func<EmployeeRole, bool>>>()))
-            .Returns(EmployeeRoleTestData.EmployeeRolesList.AsQueryable().BuildMock());
-
-        _unitOfWorkMock
-            .Setup(x => x.Role.Get(It.IsAny<Expression<Func<Role, bool>>>()))
-            .Returns(roles.AsQueryable().BuildMock());
-
-        _employeeServiceMock.Setup(x => x.GetById(employeeId))
-            .ReturnsAsync(EmployeeTestData.EmployeeDto);
+        SetupMockRoles();
 
         _unitOfWorkMock.Setup(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()))
-            .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentActionRequired);
+           .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentActionRequired);
 
         var result = await _employeeDocumentService.SaveEmployeeDocument(EmployeeDocumentTestData.SimpleDocumentDto, "test@retrorabbit.co.za", 1);
 

--- a/HRIS.Services.Tests/Services/EmployeeDocumentServiceUnitTest.cs
+++ b/HRIS.Services.Tests/Services/EmployeeDocumentServiceUnitTest.cs
@@ -154,6 +154,7 @@ public class EmployeeDocumentServiceUnitTest
         var result = await _employeeDocumentService.SaveEmployeeDocument(EmployeeDocumentTestData.SimpleDocumentDto, "test@retrorabbit.co.za", 0);
 
         Assert.NotNull(result);
+        Assert.Equal(EmployeeDocumentTestData.EmployeeDocumentPending.DocumentType, result.DocumentType);
         Assert.Equal(EmployeeDocumentTestData.EmployeeDocumentPending, result);
         _employeeServiceMock.Verify(x => x.GetById(employeeId), Times.Once);
         _unitOfWorkMock.Verify(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()), Times.Once);
@@ -204,9 +205,64 @@ public class EmployeeDocumentServiceUnitTest
         _unitOfWorkMock.Setup(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()))
             .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentPending);
 
+        var result = await _employeeDocumentService.SaveEmployeeDocument(EmployeeDocumentTestData.SimpleDocumentDto, "test@retrorabbit.co.za", 3);
+
+        Assert.NotNull(result);
+        Assert.Equal(EmployeeDocumentTestData.EmployeeDocumentPending.DocumentType, result.DocumentType);
+        Assert.Equal(EmployeeDocumentTestData.EmployeeDocumentPending, result);
+        _employeeServiceMock.Verify(x => x.GetById(employeeId), Times.Once);
+        _unitOfWorkMock.Verify(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SaveAdministrativeDocumentPass()
+    {
+        _employeeTypeServiceMock
+            .Setup(r => r.GetEmployeeType(EmployeeTypeTestData.DeveloperType.Name))
+            .ReturnsAsync(EmployeeTypeTestData.DeveloperType);
+
+        _unitOfWorkMock
+            .Setup(u => u.Employee.Get(It.IsAny<Expression<Func<Employee, bool>>>()))
+            .Returns(
+                new List<Employee>
+                {
+                    new(EmployeeTestData.EmployeeDto, EmployeeTypeTestData.DeveloperType)
+                    {
+                        EmployeeType = new EmployeeType(EmployeeTypeTestData.DeveloperType),
+                        PhysicalAddress = new EmployeeAddress(EmployeeAddressTestData.EmployeeAddressDto),
+                        PostalAddress = new EmployeeAddress(EmployeeAddressTestData.EmployeeAddressDto)
+                    }
+                }.AsQueryable().BuildMock());
+
+        _unitOfWorkMock
+            .Setup(u => u.EmployeeBanking.Get(It.IsAny<Expression<Func<EmployeeBanking, bool>>>()))
+            .Returns(
+                new List<EmployeeBanking>
+                {
+                    new(EmployeeBankingTestData.EmployeeBankingDto)
+                }.AsQueryable().BuildMock());
+
+
+
+        List<Role> roles = new List<Role> { new Role(EmployeeRoleTestData.RoleDtoEmployee) };
+        _employeeServiceMock.Setup(x => x.GetById(employeeId))
+            .ReturnsAsync(EmployeeTestData.EmployeeDto);
+
+        _unitOfWorkMock
+            .Setup(x => x.EmployeeRole.Get(It.IsAny<Expression<Func<EmployeeRole, bool>>>()))
+            .Returns(EmployeeRoleTestData.EmployeeRolesList.AsQueryable().BuildMock());
+
+        _unitOfWorkMock
+            .Setup(x => x.Role.Get(It.IsAny<Expression<Func<Role, bool>>>()))
+            .Returns(roles.AsQueryable().BuildMock());
+
+        _unitOfWorkMock.Setup(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()))
+            .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentPending);
+
         var result = await _employeeDocumentService.SaveEmployeeDocument(EmployeeDocumentTestData.SimpleDocumentDto, "test@retrorabbit.co.za", 2);
 
         Assert.NotNull(result);
+        Assert.Equal(EmployeeDocumentTestData.EmployeeDocumentPending.DocumentType, result.DocumentType);
         Assert.Equal(EmployeeDocumentTestData.EmployeeDocumentPending, result);
         _employeeServiceMock.Verify(x => x.GetById(employeeId), Times.Once);
         _unitOfWorkMock.Verify(x => x.EmployeeDocument.Add(It.IsAny<EmployeeDocument>()), Times.Once);

--- a/HRIS.Services/Services/EmployeeDocumentService.cs
+++ b/HRIS.Services/Services/EmployeeDocumentService.cs
@@ -46,6 +46,9 @@ public class EmployeeDocumentService : IEmployeeDocumentService
                 docType = DocumentType.Additional;
                 break;
             case 2:
+                docType = DocumentType.Administrative;
+                break;
+            case 3:
                 docType = DocumentType.EmployeeDocuments;
                 break;
             default:


### PR DESCRIPTION
Unit test coverage for EmployeeDocumentServiceUnitTest: added case to check for admin document type and save it to the DB

![AdminDocsUnitTestsPass](https://github.com/RetroRabbit/RGO-Server/assets/123623759/42a20524-8c63-4e83-9a83-2e2fb17be2c2)
