### PR TITLE
9021 Employee Role gets forbidden access to field codes

### DIFF
--- a/RR.App/Controllers/HRIS/FieldCodeController.cs
+++ b/RR.App/Controllers/HRIS/FieldCodeController.cs
@@ -16,7 +16,7 @@ public class FieldCodeController : Controller
         _fieldCodeService = fieldCodeService;
     }
 
-    [Authorize(Policy = "AdminOrTalentOrSuperAdminPolicy")]
+    [Authorize(Policy = "AllRolesPolicy")]
     [HttpGet]
     public async Task<IActionResult> GetAllFieldCodes()
     {


### PR DESCRIPTION
### Overview
Give the employee role access to field codes api.

**Bug**
[9021 Employee Role gets forbidden access to field codes](https://dev.azure.com/retro-rabbit/RetroGradOnboard/_sprints/taskboard/RetroGradOnboard%20Team/RetroGradOnboard/Sprint%2021?workitem=9021)

**Screenshot fix:**
![image](https://github.com/RetroRabbit/RGO-Server/assets/68727050/379ec61a-7fa2-4015-8776-2ecbcc23f0cc)
