### PR TITLE
Matthew/bug fix/admin uploading status action required

### DIFF
--- a/HRIS.Services.Tests/Services/EmployeeDocumentServiceUnitTest.cs
+++ b/HRIS.Services.Tests/Services/EmployeeDocumentServiceUnitTest.cs
@@ -514,6 +514,7 @@ public class EmployeeDocumentServiceUnitTest
     public async Task UpdateEmployeeDocumentPass()
     {
         var mockEmployeeDbSet = new List<Employee> { testEmployee }.AsQueryable().BuildMockDbSet();
+
         _unitOfWorkMock.Setup(m => m.Employee.Get(It.IsAny<Expression<Func<Employee, bool>>>()))
                   .Returns(mockEmployeeDbSet.Object);
 
@@ -521,9 +522,11 @@ public class EmployeeDocumentServiceUnitTest
 
         _unitOfWorkMock.Setup(m => m.EmployeeDocument.Update(It.IsAny<EmployeeDocument>()))
                       .ReturnsAsync(EmployeeDocumentTestData.EmployeeDocumentPending);
+
+        SetupMockRoles();
         var service = new EmployeeDocumentService(_unitOfWorkMock.Object, _employeeServiceMock.Object, _errorLoggingServiceMock.Object);
 
-        var result = await service.UpdateEmployeeDocument(EmployeeDocumentTestData.EmployeeDocumentPending);
+        var result = await service.UpdateEmployeeDocument(EmployeeDocumentTestData.EmployeeDocumentPending, "test@retrorabbit.co.za");
 
         Assert.NotNull(result);
     }
@@ -547,7 +550,7 @@ public class EmployeeDocumentServiceUnitTest
         _errorLoggingServiceMock.Setup(x => x.LogException(It.IsAny<Exception>())).Throws(new Exception("Employee not found"));
 
         var exception = await Assert.ThrowsAsync<Exception>(() =>
-                        _employeeDocumentService.UpdateEmployeeDocument(EmployeeDocumentTestData.EmployeeDocumentApproved));
+                        _employeeDocumentService.UpdateEmployeeDocument(EmployeeDocumentTestData.EmployeeDocumentApproved, "test@retrorabbit.co.za"));
 
         Assert.Equal("Employee not found", exception.Message);
 

--- a/HRIS.Services/Interfaces/IEmployeeDocumentService.cs
+++ b/HRIS.Services/Interfaces/IEmployeeDocumentService.cs
@@ -40,7 +40,7 @@ public interface IEmployeeDocumentService
     /// </summary>
     /// <param name="employeeDocumentDto"></param>
     /// <returns>Employee Document</returns>
-    Task<EmployeeDocumentDto> UpdateEmployeeDocument(EmployeeDocumentDto employeeDocumentDto);
+    Task<EmployeeDocumentDto> UpdateEmployeeDocument(EmployeeDocumentDto employeeDocumentDto, string email);
 
     /// <summary>
     /// Delete Employee Document

--- a/RR.App/Controllers/HRIS/EmployeeDocumentController.cs
+++ b/RR.App/Controllers/HRIS/EmployeeDocumentController.cs
@@ -69,7 +69,8 @@ public class EmployeeDocumentController : ControllerBase
     {
         try
         {
-            var updatedEmployeeDocument = await _employeeDocumentService.UpdateEmployeeDocument(employeeDocumentDto);
+            var claimsIdentity = this.User.Identity as ClaimsIdentity;
+            var updatedEmployeeDocument = await _employeeDocumentService.UpdateEmployeeDocument(employeeDocumentDto, claimsIdentity?.FindFirst(ClaimTypes.Email)?.Value!);
             return Ok(updatedEmployeeDocument);
         }
         catch (Exception)


### PR DESCRIPTION
**Problem**:
- Admin document uploads on other employee profile should remain as action required

Description:
Changed the update method in the service to run a check of weather admin is changing a document for someone else's profile.

Bug Ticket:
[9027](https://dev.azure.com/retro-rabbit/RetroGradOnboard/_workitems/edit/9027)
