### PR TITLE
Fixing work experience service to return list and not object

### DIFF
--- a/HRIS.Services/Interfaces/IWorkExperience.cs
+++ b/HRIS.Services/Interfaces/IWorkExperience.cs
@@ -30,5 +30,5 @@ public interface IWorkExperienceService
     /// <param name="employeeId"></param>
     /// <param name="status"></param>
     /// <returns>Employee Work experience</returns>
-    Task<WorkExperienceDto> GetWorkExperienceByEmployeeId(int id);
+    Task<List<WorkExperienceDto>> GetWorkExperienceByEmployeeId(int id);
 }

--- a/HRIS.Services/Services/WorkExperienceService.cs
+++ b/HRIS.Services/Services/WorkExperienceService.cs
@@ -62,12 +62,12 @@ public class WorkExperienceService : IWorkExperienceService
         return await _db.WorkExperience.Delete(workExperienceId);
     }
 
-    public async Task<WorkExperienceDto> GetWorkExperienceByEmployeeId(int id)
+    public async Task<List<WorkExperienceDto>> GetWorkExperienceByEmployeeId(int id)
     {
         return await _db.WorkExperience
              .Get(workExperience => workExperience.EmployeeId == id)
              .Select(workExperience => workExperience.ToDto())
-             .FirstAsync();
+             .ToListAsync();
     }
 }
 

--- a/RR.App.Tests/Controllers/HRIS/WorkExperienceControllerUnitTest.cs
+++ b/RR.App.Tests/Controllers/HRIS/WorkExperienceControllerUnitTest.cs
@@ -91,30 +91,32 @@ public class WorkExperienceControllerUnitTest
     [Fact]
     public async Task GetWorkExperienceByIdPass()
     {
+        var workExperienceList = new List<WorkExperienceDto> { workExperience };
+
         _workExperienceServiceMock
            .Setup(x => x
-               .GetWorkExperienceByEmployeeId(workExperience.Id))
-           .ReturnsAsync(workExperience);
+           .GetWorkExperienceByEmployeeId(workExperience.EmployeeId))
+           .ReturnsAsync(workExperienceList);
 
         var controllerResult = await _controller
-            .GetWorkExperienceById(workExperience.Id);
+            .GetWorkExperienceById(workExperience.EmployeeId);
 
         var actionResult = Assert.IsType<OkObjectResult>(controllerResult);
 
         Assert.NotNull(actionResult.Value);
-        Assert.Equal(workExperience, actionResult.Value);
+        Assert.Equal(workExperienceList, actionResult.Value);
     }
 
     [Fact]
     public async Task GetWorkExperienceByIdFail()
     {
         _workExperienceServiceMock
-           .Setup(x => x
-               .GetWorkExperienceByEmployeeId(workExperience.Id))
-           .ThrowsAsync(new Exception());
+       .Setup(x => x
+           .GetWorkExperienceByEmployeeId(workExperience.EmployeeId))
+       .ThrowsAsync(new Exception());
 
         var controllerResult = await _controller
-            .GetWorkExperienceById(workExperience.Id);
+            .GetWorkExperienceById(workExperience.EmployeeId);
 
         var actionResult = Assert.IsType<NotFoundObjectResult>(controllerResult);
 


### PR DESCRIPTION
**Description:**

- In the front end the data that was returned was an object. The required data had to be a list instead. The service and interface has been updated for the requirements