### PR TITLE
Qualification service fix for throwing exception when user has no qualifications

### DIFF
--- a/HRIS.Services.Tests/Services/EmployeeQualificationServiceUnitTests.cs
+++ b/HRIS.Services.Tests/Services/EmployeeQualificationServiceUnitTests.cs
@@ -149,26 +149,6 @@ public class EmployeeQualificationServiceUnitTests
             Times.Never);
     }
 
-    [Fact]
-    public async Task GetEmployeeQualificationsByEmployeeId_Failure_NoQualifications()
-    {
-        _employeeService.Setup(x => x.GetEmployeeById(It.IsAny<int>()))
-            .ReturnsAsync(EmployeeTestData.EmployeeOne.ToDto());
-        _db.Setup(
-                x => x.EmployeeQualification.FirstOrDefault(It.IsAny<Expression<Func<EmployeeQualification, bool>>>()))
-            .ReturnsAsync(default(EmployeeQualification));
-
-        var exception = await Assert.ThrowsAsync<CustomException>(() =>
-            _employeeQualificationService.GetEmployeeQualificationsByEmployeeId(EmployeeId));
-
-        Assert.Equivalent("Unable to Load Employee Qualifications", exception.Message);
-
-        _employeeService.Verify(x => x.GetEmployeeById(It.IsAny<int>()), Times.Once);
-        _db.Verify(
-            x => x.EmployeeQualification.FirstOrDefault(It.IsAny<Expression<Func<EmployeeQualification, bool>>>()),
-            Times.Once);
-    }
-
     #endregion
 
     #region UpdateEmployeeQualification

--- a/HRIS.Services/Services/EmployeeQualificationService.cs
+++ b/HRIS.Services/Services/EmployeeQualificationService.cs
@@ -43,7 +43,7 @@ public class EmployeeQualificationService : IEmployeeQualificationService
     {
         var employee = await _employeeService.GetEmployeeById(employeeId);
         var qualifications = await _db.EmployeeQualification.FirstOrDefault(x => x.EmployeeId == employee.Id);
-        return qualifications?.ToDto() ?? throw new CustomException("Unable to Load Employee Qualifications");
+        return qualifications?.ToDto();
     }
 
     public async Task<EmployeeQualificationDto> UpdateEmployeeQualification(


### PR DESCRIPTION
- The qualification service threw an exception when the user has no qualifications added and gave error
- Removed the unit test for the exception 
![image](https://github.com/RetroRabbit/RGO-Server/assets/156097906/909d7d60-23dc-4a57-9e93-8560ba3856c2)