### PR TITLE
Hotfix | banking starterkits logic error

### DIFF
--- a/HRIS.Services.Tests/Services/DashboardServiceUnitTest.cs
+++ b/HRIS.Services.Tests/Services/DashboardServiceUnitTest.cs
@@ -51,7 +51,7 @@ public class DashboardServiceUnitTest
 
         var result = await _dashboardService.CalculateEmployeeChurnRate();
         Assert.NotNull(result);
-        Assert.Equal("July", result.Month);
+        Assert.Equal(DateTime.UtcNow.ToString("MMMM"), result.Month);
         Assert.Equal(0, result.ChurnRate);
         Assert.Equal(0, result.DeveloperChurnRate);
         Assert.Equal(0, result.DesignerChurnRate);

--- a/HRIS.Services/Services/EmployeeDocumentService.cs
+++ b/HRIS.Services/Services/EmployeeDocumentService.cs
@@ -27,7 +27,7 @@ public class EmployeeDocumentService : IEmployeeDocumentService
 
         var sameEmail = email.Equals(employee.Email);
         var isAdmin = await IsAdmin(email);
-        var status = isAdmin && !sameEmail ? DocumentStatus.ActionRequired : DocumentStatus.PendingApproval;
+        var status = isAdmin && !sameEmail ? DocumentStatus.PendingApproval : DocumentStatus.ActionRequired;
         var docType = DocumentType.StarterKit;
 
         switch (documentType)
@@ -162,10 +162,7 @@ public class EmployeeDocumentService : IEmployeeDocumentService
             .Select(employee => employee.Email)
             .FirstAsync();
 
-
         var sameEmail = email.Equals(employeeEmail);
-        var isAdmin = await IsAdmin(email);
-        if (isAdmin && !sameEmail) employeeDocumentDto.Status = DocumentStatus.ActionRequired;
 
         var employeeDocument = new EmployeeDocument(employeeDocumentDto);
 


### PR DESCRIPTION
### Overview

A unit test was set to static "July" month, whereas it needs to be dynamic.

The logic for adding starter kit docs was incorrect.